### PR TITLE
Reexport all operators in aioreactive.operators

### DIFF
--- a/aioreactive/core/observers.py
+++ b/aioreactive/core/observers.py
@@ -23,7 +23,7 @@ class AsyncIteratorObserver(AsyncObserverBase[T], AsyncIterable[T]):
         self._busy = False
 
     async def asend_core(self, value: T) -> None:
-        log.debug("AsyncIteratorObserver:asend(%d)", value)
+        log.debug("AsyncIteratorObserver:asend(%s)", value)
 
         await self._serialize_access()
 

--- a/aioreactive/operators/__init__.py
+++ b/aioreactive/operators/__init__.py
@@ -1,5 +1,6 @@
 from . import pipe as op
 
+from .catch_exception import catch_exception
 from .concat import concat
 from .debounce import debounce
 from .delay import delay
@@ -7,15 +8,21 @@ from .distinct_until_changed import distinct_until_changed
 from .empty import empty
 from .filter import filter
 from .filteri import filteri
+from .flat_map import flat_map
 from .from_async_iterable import from_async_iterable
 from .from_iterable import from_iterable
-from .flat_map import flat_map, flat_map_latest
 from .map import map
 from .max import max
 from .merge import merge
+from .never import never
 from .retry import retry
 from .scan import scan
-from .switch_latest import switch_latest
 from .skip import skip
+from .skip_last import skip_last
+from .slice import slice
+from .switch_latest import switch_latest
 from .take import take
+from .take_last import take_last
+from .to_async_iterable import to_async_iterable
 from .unit import unit
+from .with_latest_from import with_latest_from

--- a/aioreactive/testing/observer.py
+++ b/aioreactive/testing/observer.py
@@ -31,7 +31,7 @@ class AsyncAnonymousObserver(AsyncObserverBase):
         self._close = close
 
     async def asend_core(self, value: T):
-        print("AsyncAnonymousObserver:asend_core(%d)" % value)
+        print("AsyncAnonymousObserver:asend_core(%s)" % value)
         time = self._loop.time()
         self._values.append((time, value))
 


### PR DESCRIPTION
Just noticed that some of the operations aren't reexported from `aioreactive.operators` that are exposed in other places (like `Operations`).

I'd like to see this fixed as I've been playing with Hy, which had threading macros making this the preferable way of building a stream. For example, the autocomplete example snippet becomes:

```
(import [aioreactive [operators :as op]]
        [aioreactive.core [AsyncStream])

(setv stream (AsyncStream)
      xs (->> stream
              (op.map (fn [x] (.rstrip (get x "term"))))
              (op.filter (fn [term] (> (len term) 2)))
              (op.debounce 0.5)
              (op.distinct-until-changed)
              (op.flat-map search-wikipedia))
```