### PR TITLE
Fix debug log/print with tuples

### DIFF
--- a/aioreactive/core/observers.py
+++ b/aioreactive/core/observers.py
@@ -23,7 +23,7 @@ class AsyncIteratorObserver(AsyncObserverBase[T], AsyncIterable[T]):
         self._busy = False
 
     async def asend_core(self, value: T) -> None:
-        log.debug("AsyncIteratorObserver:asend(%d)", value)
+        log.debug("AsyncIteratorObserver:asend(%s)", value)
 
         await self._serialize_access()
 

--- a/aioreactive/operators/from_iterable.py
+++ b/aioreactive/operators/from_iterable.py
@@ -29,7 +29,7 @@ class FromIterable(AsyncObservable, Generic[T]):
             log.debug("sync_worker()")
             for value in self.iterable:
                 try:
-                    log.debug("sync_worker. asending: %s" % value)
+                    log.debug("sync_worker. asending: %s", value)
                     await observer.asend(value)
                 except Exception as ex:
                     await observer.athrow(ex)

--- a/aioreactive/operators/merge.py
+++ b/aioreactive/operators/merge.py
@@ -45,7 +45,7 @@ class Merge(AsyncObservable):
             self._inner_subs = {}
 
         async def asend_core(self, stream: AsyncObservable) -> None:
-            log.debug("Merge.Sink:asend_core(%s)" % stream)
+            log.debug("Merge.Sink:asend_core(%s)", stream)
 
             inner_stream = Merge.Sink.InnerStream()
             inner_sub = await chain(inner_stream, self._observer)  # type: AsyncDisposable

--- a/aioreactive/operators/switch_latest.py
+++ b/aioreactive/operators/switch_latest.py
@@ -34,7 +34,7 @@ class SwitchLatest(AsyncObservable):
             self.latest = 0
 
         async def asend(self, stream) -> None:
-            log.debug("SwitchLatest._:send(%s)" % stream)
+            log.debug("SwitchLatest._:send(%s)", stream)
             inner_observer = await chain(SwitchLatest.Sink.Inner(self), self._observer)
 
             self._latest = id(inner_observer)

--- a/aioreactive/testing/observer.py
+++ b/aioreactive/testing/observer.py
@@ -31,7 +31,7 @@ class AsyncAnonymousObserver(AsyncObserverBase):
         self._close = close
 
     async def asend_core(self, value: T):
-        print("AsyncAnonymousObserver:asend_core(%d)" % value)
+        print("AsyncAnonymousObserver:asend_core(%d)" % (value,))
         time = self._loop.time()
         self._values.append((time, value))
 

--- a/aioreactive/testing/observer.py
+++ b/aioreactive/testing/observer.py
@@ -31,7 +31,7 @@ class AsyncAnonymousObserver(AsyncObserverBase):
         self._close = close
 
     async def asend_core(self, value: T):
-        print("AsyncAnonymousObserver:asend_core(%d)" % (value,))
+        print("AsyncAnonymousObserver:asend_core(%s)" % (value,))
         time = self._loop.time()
         self._values.append((time, value))
 


### PR DESCRIPTION
`"debug_str %s" % any_tuple` would otherwise unpack it. Fixes #14.